### PR TITLE
Patch unit tests for HashSet ordering in Java 8.

### DIFF
--- a/test/com/google/enterprise/adaptor/ad/AdAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/ad/AdAdaptorTest.java
@@ -1184,7 +1184,8 @@ public class AdAdaptorTest {
         assertTrue("results did not have key " + key, results.containsKey(key));
         assertNull("non-null result for key " + key, results.get(key));
       } else {
-        assertEquals(value, results.get(key));
+        // Compare the lists for unordered equality, ignoring duplicates.
+        assertEquals(Sets.newHashSet(value), Sets.newHashSet(results.get(key)));
       }
     }
   }

--- a/test/com/google/enterprise/adaptor/ad/AdAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/ad/AdAdaptorTest.java
@@ -1185,6 +1185,7 @@ public class AdAdaptorTest {
         assertNull("non-null result for key " + key, results.get(key));
       } else {
         // Compare the lists for unordered equality, ignoring duplicates.
+        assertNotNull("null result for key " + key, results.get(key));
         assertEquals(Sets.newHashSet(value), Sets.newHashSet(results.get(key)));
       }
     }


### PR DESCRIPTION
This is a hack for treating the List<Principal> in the groups map as
unordered. This is a small change because an assertEquals was expanded
to the java.util.AbstractMap#equals implementation in commit 592b00e.

Two more intrusive fixes are to change the internal
Map<GroupPrincipal, List<Principal>> to use a Set instead of a Map, so
the comparison is always unordered, or to change the members map in
AdEntity to a TreeMap, for predictable ordering (using LinkedHashMap
does not work, though that may be due to the setup in the tests). The
performance of those changes would need to be tested at scale, and
it's only the tests that care about the ordering.