### PR TITLE
Fix lint errors.

### DIFF
--- a/src/com/google/enterprise/adaptor/ad/AdAdaptor.java
+++ b/src/com/google/enterprise/adaptor/ad/AdAdaptor.java
@@ -594,8 +594,8 @@ public class AdAdaptor extends AbstractAdaptor
         bySid.put(e.getSid(), e);
         byDn.put(e.getDn(), e);
         // TODO(pjo): Have AdServer put domain into AdEntity during search
-        domain.put(e, e.getSid().startsWith("S-1-5-32-") ?
-            localizedStrings.get("Builtin") : nETBIOSName);
+        domain.put(e, e.getSid().startsWith("S-1-5-32-")
+            ? localizedStrings.get("Builtin") : nETBIOSName);
       }
       initializeMembers(entities);
       resolvePrimaryGroups(entities);
@@ -635,8 +635,8 @@ public class AdAdaptor extends AbstractAdaptor
           // b/18028678: remove user from old primary group (if needed)
           String oldPrimaryGroupSid = oldEntity.getPrimaryGroupSid();
           String newPrimaryGroupSid = e.getPrimaryGroupSid();
-          if (oldPrimaryGroupSid != null &&
-              !oldPrimaryGroupSid.equals(newPrimaryGroupSid)) {
+          if (oldPrimaryGroupSid != null
+              && !oldPrimaryGroupSid.equals(newPrimaryGroupSid)) {
             AdEntity oldPrimaryGroup = bySid.get(oldPrimaryGroupSid);
             if (oldPrimaryGroup == null) {
               log.log(Level.WARNING,
@@ -713,8 +713,7 @@ public class AdAdaptor extends AbstractAdaptor
               new Object[]{user.getPrimaryGroupSid(), user});
           continue;
         }
-        if (!primaryMembers.containsKey(primaryGroup) ||
-            (null == primaryMembers.get(primaryGroup))) {
+        if (primaryMembers.get(primaryGroup) == null) {
           primaryMembers.put(primaryGroup, new TreeSet<String>());
         }
         primaryMembers.get(primaryGroup).add(user.getDn());
@@ -871,8 +870,8 @@ public class AdAdaptor extends AbstractAdaptor
      * principal name.
      */
     String getPrincipalName(AdEntity e) {
-      return domain.get(e) != null ?
-          e.getSAMAccountName() + "@" + domain.get(e) : e.getSAMAccountName();
+      return domain.get(e) != null
+          ? e.getSAMAccountName() + "@" + domain.get(e) : e.getSAMAccountName();
     }
 
     /* Combines info of another catalog with this one. */

--- a/src/com/google/enterprise/adaptor/ad/AdEntity.java
+++ b/src/com/google/enterprise/adaptor/ad/AdEntity.java
@@ -327,15 +327,15 @@ public class AdEntity {
     }
     AdEntity other = (AdEntity) o;
     return dn.equals(other.dn)
-        && ((sAMAccountName == null) ? (other.sAMAccountName == null) :
-            sAMAccountName.equals(other.sAMAccountName))
-        && ((userPrincipalName == null) ? (other.userPrincipalName == null) :
-            userPrincipalName.equals(other.userPrincipalName))
-        && ((primaryGroupId == null) ? (other.primaryGroupId == null) :
-            primaryGroupId.equals(other.primaryGroupId))
+        && ((sAMAccountName == null) ? (other.sAMAccountName == null)
+            : sAMAccountName.equals(other.sAMAccountName))
+        && ((userPrincipalName == null) ? (other.userPrincipalName == null)
+            : userPrincipalName.equals(other.userPrincipalName))
+        && ((primaryGroupId == null) ? (other.primaryGroupId == null)
+            : primaryGroupId.equals(other.primaryGroupId))
         && ((sid == null) ? (other.sid == null) : sid.equals(other.sid))
-        && ((members == null) ? (other.members == null) :
-            members.equals(other.members))
+        && ((members == null) ? (other.members == null)
+            : members.equals(other.members))
         && uSNChanged == other.uSNChanged
         && userAccountControl == other.userAccountControl;
         // note: 3 fields (objectGUID, wellKnown, and allMembershipsRetrieved)

--- a/src/com/google/enterprise/adaptor/ad/Method.java
+++ b/src/com/google/enterprise/adaptor/ad/Method.java
@@ -14,6 +14,7 @@
 
 package com.google.enterprise.adaptor.ad;
 
+/** Enumerates the LDAP connection methods. */
 public enum Method {
   STANDARD, SSL;
 

--- a/test/com/google/enterprise/adaptor/ad/AdEntityTest.java
+++ b/test/com/google/enterprise/adaptor/ad/AdEntityTest.java
@@ -14,13 +14,21 @@
 
 package com.google.enterprise.adaptor.ad;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 
-import javax.naming.directory.*;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.SearchResult;
 
 /** Test cases for {@link AdEntity}. */
 public class AdEntityTest {
@@ -173,7 +181,7 @@ public class AdEntityTest {
     attrs.put("member", null);
     Attribute memberAttr = attrs.get("member");
     memberAttr.clear();
-    for (String member: members) {
+    for (String member : members) {
       memberAttr.add(member);
     }
 

--- a/test/com/google/enterprise/adaptor/ad/AdServerTest.java
+++ b/test/com/google/enterprise/adaptor/ad/AdServerTest.java
@@ -14,7 +14,11 @@
 
 package com.google.enterprise.adaptor.ad;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.enterprise.adaptor.InvalidConfigurationException;
 
@@ -22,11 +26,22 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Vector;
 
-import javax.naming.*;
-import javax.naming.directory.*;
-import javax.naming.ldap.*;
+import javax.naming.CommunicationException;
+import javax.naming.InterruptedNamingException;
+import javax.naming.NameNotFoundException;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.Control;
 
 /** Test cases for {@link AdServer}. */
 public class AdServerTest {

--- a/test/com/google/enterprise/adaptor/ad/MockLdapContext.java
+++ b/test/com/google/enterprise/adaptor/ad/MockLdapContext.java
@@ -16,11 +16,19 @@ package com.google.enterprise.adaptor.ad;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import java.io.*;
-import java.util.*;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.NoSuchElementException;
+import java.util.Vector;
 
-import javax.naming.*;
-import javax.naming.directory.*;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
 import javax.naming.ldap.Control;
 import javax.naming.ldap.InitialLdapContext;
 
@@ -99,7 +107,7 @@ public class MockLdapContext extends InitialLdapContext {
     if (value instanceof Collection<?>) {
       Attribute attr = attrs.get(newAttr);
       attr.clear();
-      for (Object member: (Collection<?>) value) {
+      for (Object member : (Collection<?>) value) {
         attr.add(member);
       }
     }


### PR DESCRIPTION
The only non-trivial change was to drop the redundant call to
Map.containsKey in:

    !containsKey(k) || get(k) == null