### PR TITLE
Java 9 compatibility.

### DIFF
--- a/build.properties.sample
+++ b/build.properties.sample
@@ -2,11 +2,10 @@
 # These properties are specific to the individual's development environment.
 #
 
-# Default JDK 6 installation location for Mac OS X.
-# However Macs haven't shipped with Java 6 for years.
-jdk6.home = /System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home
+# Default JDK 7 installation location for Mac OS X.
+jdk7.home = /Library/Java/JavaVirtualMachines/jdk1.7.0_76.jdk/Contents/Home
 
-# JDK 6 bootclasspath.
-build.bootclasspath = ${jdk6.home}/jre/lib/classes.jar\
-    :${jdk6.home}/jre/lib/jsse.jar\
-    :${jdk6.home}/jre/lib/jce.jar
+# JDK 7 bootclasspath.
+build.bootclasspath = ${jdk7.home}/jre/lib/rt.jar\
+    :${jdk7.home}/jre/lib/jsse.jar\
+    :${jdk7.home}/jre/lib/jce.jar

--- a/build.xml
+++ b/build.xml
@@ -23,15 +23,21 @@
   <property name="cobertura.dir" value="${basedir}/../cobertura/"/>
   <!-- Load build environment specific properties. -->
   <property file="build.properties"/>
-  <property name="compile.java.source" value="6"/>
-  <property name="compile.java.target" value="7"/>
+  <property name="compile.java.version" value="7"/>
   <property name="compile.java.bootclasspath" value="${build.bootclasspath}"/>
   <!-- The build.bootclasspath property, if set, must match the Java version
        set in compile.java.version. To detect errors in build.bootclasspath,
        set compile.java.newerClassname to a class that was added in
        the immediately following release of Java. For example, for
-       "6", pick a class added in Java 7. -->
-  <property name="compile.java.newerClassname" value="java.lang.AutoCloseable"/>
+       "7", pick a class added in Java 8. -->
+  <property name="compile.java.newerClassname"
+    value="java.lang.FunctionalInterface"/>
+
+  <!-- Use add-modules with Java 9 and higher. -->
+  <condition property="java.modules"
+      value="" else="--add-modules java.xml.bind">
+    <matches string="${ant.java.version}" pattern="^1\.[678]$"/>
+  </condition>
 
   <path id="adaptor.build.classpath">
     <pathelement location="${adaptor.jar}"/>
@@ -116,12 +122,12 @@ lib/plexi submodule or add the the command line argument
       classname="${compile.java.newerClassname}"
       classpath="${compile.java.bootclasspath}" ignoresystemclasses="true"/>
     <fail if="compile.java.isNewer">
-      Error: build.bootclasspath is newer than JDK ${compile.java.source}.
+      Error: build.bootclasspath is newer than JDK ${compile.java.version}.
     </fail>
 
     <javac srcdir="${src.dir}" destdir="${build-src.dir}" debug="true"
       includeantruntime="false" encoding="utf-8"
-      source="${compile.java.source}" target="${compile.java.target}">
+      source="${compile.java.version}" target="${compile.java.version}">
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <compilerarg line="-Xlint -Xlint:-serial"/>
       <classpath refid="adaptor.build.classpath"/>
@@ -131,7 +137,7 @@ lib/plexi submodule or add the the command line argument
     <!-- Compile JUnit helper -->
     <javac srcdir="${lib.dir}" destdir="${build-test.dir}" debug="true"
       includeantruntime="true" encoding="utf-8"
-      source="${compile.java.source}" target="${compile.java.target}">
+      source="${compile.java.version}" target="${compile.java.version}">
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <compilerarg line="-Xlint -Xlint:-serial"/>
       <classpath refid="junit.classpath"/>
@@ -141,7 +147,7 @@ lib/plexi submodule or add the the command line argument
     <!-- Compile tests, excluding example tests. -->
     <javac srcdir="${test.dir}" destdir="${build-test.dir}" debug="true"
       includeantruntime="false" encoding="utf-8"
-      source="${compile.java.source}" target="${compile.java.target}">
+      source="${compile.java.version}" target="${compile.java.version}">
       <bootclasspath path="${compile.java.bootclasspath}"/>
       <compilerarg line="-Xlint -Xlint:-serial"/>
       <classpath refid="adaptor.build.classpath"/>
@@ -251,6 +257,7 @@ lib/plexi submodule or add the the command line argument
 
   <target name="run" depends="build" description="Run adaptor">
     <java classpath="${build-src.dir}" fork="true" classname="${adaptor.class}">
+      <jvmarg line="${java.modules}"/>
       <classpath refid="adaptor.run.classpath"/>
       <sysproperty key="java.util.logging.config.file"
         value="logging.properties"/>


### PR DESCRIPTION
Deprecated features:

* javac -source and -target value of 1.6 (require Java 7)

Java EE features:

* Add --add-modules java.xml.bind; also requires Ant 1.9.4 or later